### PR TITLE
Update affiliate link

### DIFF
--- a/360-software/index.html
+++ b/360-software/index.html
@@ -1490,7 +1490,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/360-tour/index.html
+++ b/360-tour/index.html
@@ -1490,7 +1490,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/360-virtual-tour-software/index.html
+++ b/360-virtual-tour-software/index.html
@@ -1491,7 +1491,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/360-virtual-tour/index.html
+++ b/360-virtual-tour/index.html
@@ -1489,7 +1489,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/3d-tour/index.html
+++ b/3d-tour/index.html
@@ -1491,7 +1491,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/3d-virtual-house-tours/index.html
+++ b/3d-virtual-house-tours/index.html
@@ -1491,7 +1491,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/3d-virtual-tours/index.html
+++ b/3d-virtual-tours/index.html
@@ -1491,7 +1491,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/404.html
+++ b/404.html
@@ -185,7 +185,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/add-to-cart/index.html
+++ b/add-to-cart/index.html
@@ -1170,7 +1170,7 @@
 								<a href="/tour-hosting" class="nav-link">Tour Hosting Details</a>
 							</li>
 							<li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -136,7 +136,7 @@
 							<a href="/tour-hosting" class="nav-link">Tour Hosting Details</a>
 						</li>
 						<li>
-							<a href="https://blog.cloudpano.com/affiliate-success-page/">
+							<a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
 								Become an Affiliate
 							</a>
 						</li>

--- a/how-to-create-a-virtual-tour-for-free/index.html
+++ b/how-to-create-a-virtual-tour-for-free/index.html
@@ -1490,7 +1490,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/how-to-create-a-virtual-tour/index.html
+++ b/how-to-create-a-virtual-tour/index.html
@@ -1490,7 +1490,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/how-to-make-a-virtual-tour/index.html
+++ b/how-to-make-a-virtual-tour/index.html
@@ -1490,7 +1490,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/index.html
+++ b/index.html
@@ -1460,7 +1460,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/real-estate-tour/index.html
+++ b/real-estate-tour/index.html
@@ -1491,7 +1491,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/starter-kit/index.html
+++ b/starter-kit/index.html
@@ -427,7 +427,7 @@ developers to easy VR app programming. For technical questions, please contact t
               </li>
               <li><a href="/starter-kit" class="nav-link">360 Tour Starter Kit</a></li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/team/index.html
+++ b/team/index.html
@@ -246,7 +246,7 @@
 									<a href="/tour-hosting" class="nav-link">Tour Hosting Details</a>
 								</li>
 								<li>
-									<a href="https://blog.cloudpano.com/affiliate-success-page/">
+									<a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
 										Become an Affiliate
 									</a>
 								</li>

--- a/tour-creator/index.html
+++ b/tour-creator/index.html
@@ -1491,7 +1491,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/virtual-home-tours/index.html
+++ b/virtual-home-tours/index.html
@@ -1491,7 +1491,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/virtual-house-tours/index.html
+++ b/virtual-house-tours/index.html
@@ -1491,7 +1491,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/virtual-real-estate/index.html
+++ b/virtual-real-estate/index.html
@@ -1491,7 +1491,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/virtual-reality-real-estate/index.html
+++ b/virtual-reality-real-estate/index.html
@@ -1491,7 +1491,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/virtual-reality-software/index.html
+++ b/virtual-reality-software/index.html
@@ -1491,7 +1491,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/virtual-reality-tours/index.html
+++ b/virtual-reality-tours/index.html
@@ -1491,7 +1491,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/virtual-tour-app/index.html
+++ b/virtual-tour-app/index.html
@@ -1490,7 +1490,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/virtual-tour-creator/index.html
+++ b/virtual-tour-creator/index.html
@@ -1490,7 +1490,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/virtual-tour-real-estate/index.html
+++ b/virtual-tour-real-estate/index.html
@@ -1491,7 +1491,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/virtual-tour-software/index.html
+++ b/virtual-tour-software/index.html
@@ -1491,7 +1491,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/virtual-tour/index.html
+++ b/virtual-tour/index.html
@@ -1491,7 +1491,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/vr-real-estate/index.html
+++ b/vr-real-estate/index.html
@@ -1491,7 +1491,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/vr-software/index.html
+++ b/vr-software/index.html
@@ -1491,7 +1491,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>

--- a/vr-tour/index.html
+++ b/vr-tour/index.html
@@ -1491,7 +1491,7 @@
                 >
               </li>
               <li>
-                <a href="https://blog.cloudpano.com/affiliate-success-page/">
+                <a href="https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/">
                   Become an Affiliate
                 </a>
               </li>


### PR DESCRIPTION
PR will replace the old link `Become an Affiliate` address  to `https://blog.cloudpano.com/how-to-become-an-affiliate-for-cloudpano-com/`. Link to [issue](https://trello.com/c/zoZzYtb3/351-70-quick-hit-add-link-in-footer).